### PR TITLE
fix(logger): persist logs across restarts with daily rotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eventsource-parser": "^3.1.0",
         "fuse.js": "^7.4.2",
         "winston": "^3.19.0",
+        "winston-daily-rotate-file": "^5.0.0",
         "winston-transport": "^4.9.0",
         "zod": "^4.4.3"
       },
@@ -4832,6 +4833,15 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -6270,6 +6280,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6381,6 +6400,15 @@
       "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -8304,6 +8332,24 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
       }
     },
     "node_modules/winston-transport": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "eventsource-parser": "^3.1.0",
     "fuse.js": "^7.4.2",
     "winston": "^3.19.0",
+    "winston-daily-rotate-file": "^5.0.0",
     "winston-transport": "^4.9.0",
     "zod": "^4.4.3"
   },

--- a/src/common/logger/index.ts
+++ b/src/common/logger/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions -- winston formatter values are stringified for logging output */
 
 import { createLogger, format, transports } from 'winston';
+import DailyRotateFile from 'winston-daily-rotate-file';
 
 import { WebhookTransport } from './webhookTransport.js';
 
@@ -33,8 +34,9 @@ export const logger = createLogger({
       handleExceptions: true,
       level: 'info',
     }),
-    new transports.File({
-      filename: 'logs/bot.log',
+    new DailyRotateFile({
+      datePattern: 'YYYY-MM-DD',
+      filename: 'logs/bot-%DATE%.log',
       format: format.combine(
         format.timestamp({
           format: 'YYYY-MM-DD HH:mm:ss',
@@ -49,9 +51,8 @@ export const logger = createLogger({
       ),
       handleExceptions: true,
       level: 'debug',
-      options: {
-        flags: 'w',
-      },
+      maxFiles: '30d',
+      maxSize: '20m',
     }),
     new WebhookTransport(),
   ],


### PR DESCRIPTION
## Problem

The file transport opened `logs/bot.log` with `flags: 'w'`, which **truncates the log on every process start**. Combined with container recreation on image updates (e.g. Watchtower), which discards the previous container's Docker logs, this left **no durable record of activity before the most recent restart**.

This surfaced while investigating why a ticket thread was closed: the thread was created ~23h before the running container existed, so neither `logs/bot.log` (truncated) nor `docker logs` (new container) had any trace of its history.

## Change

Replace the `File` transport with [`winston-daily-rotate-file`](https://github.com/winstonjs/winston-daily-rotate-file):

- **Append mode** — no more truncation on startup
- **Dated files** — `logs/bot-%DATE%.log` (`YYYY-MM-DD`)
- **Bounded** — `maxSize: 20m`, `maxFiles: 30d` retention

Console and webhook transports are unchanged. The file format (no colorization) is preserved.

## Verification

- `npm run check` (tsc) ✅
- `npm run lint` (eslint) ✅
- `npm run build` (esbuild + tsc-alias) ✅

## Notes

- `logs` and `*.log` are already gitignored, so the dated files and the rotation audit file are covered.
- Optionally, granting the bot the `View Audit Log` permission would let it attribute manual moderator actions on threads (currently returns 403).