### PR TITLE
feat(chat): render the generic chat SSE event protocol

### DIFF
--- a/src/common/types/StreamEvent.ts
+++ b/src/common/types/StreamEvent.ts
@@ -1,0 +1,6 @@
+export type StreamEvent =
+  | { code: string; message: string; type: 'error' }
+  | { label: string; state?: string; tool?: string; type: 'status' }
+  | { text: string; type: 'token' }
+  | { type: 'done' }
+  | { type: 'reset' };

--- a/src/common/utils/messages.ts
+++ b/src/common/utils/messages.ts
@@ -6,10 +6,12 @@ import {
   type UserContextMenuCommandInteraction,
 } from 'discord.js';
 
+import type { StreamEvent } from '@/common/types/StreamEvent.js';
+
 import { labels } from '@/translations/labels.js';
 
-type ChunkProducer = (
-  callback: (chunk: string) => Promise<void>,
+type EventProducer = (
+  emit: (event: StreamEvent) => Promise<void>,
 ) => Promise<void>;
 
 type StreamableInteraction =
@@ -144,15 +146,21 @@ const smartSplit = (text: string, maxLength: number): [string, string] => {
 const MAX_STREAM_LENGTH = 2_000;
 
 const runStreaming = async (
-  produce: ChunkProducer,
+  produce: EventProducer,
   flush: (index: number, content: string) => Promise<void>,
 ) => {
   const buffers: string[] = [''];
   let lastEdit = Date.now();
 
-  const handleChunk = async (chunk: string) => {
+  const flushAll = async () => {
+    for (const [index, buffer] of buffers.entries()) {
+      await flush(index, buffer);
+    }
+  };
+
+  const appendText = (text: string) => {
     let bufferIndex = buffers.length - 1;
-    buffers[bufferIndex] += chunk;
+    buffers[bufferIndex] += text;
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bufferIndex is derived from buffers.length and always points at an existing entry here
     while (buffers[bufferIndex]!.length > MAX_STREAM_LENGTH) {
@@ -162,26 +170,48 @@ const runStreaming = async (
       buffers.push(tail);
       bufferIndex++;
     }
+  };
 
-    const now = Date.now();
-    if (now - lastEdit > 1_000) {
-      lastEdit = now;
-      for (const [index, buffer] of buffers.entries()) {
-        await flush(index, buffer);
+  const handleEvent = async (event: StreamEvent) => {
+    switch (event.type) {
+      case 'done':
+        return;
+      case 'error': {
+        const current = buffers.at(-1) ?? '';
+        appendText(current ? `\n\n${event.message}` : event.message);
+        lastEdit = Date.now();
+        await flushAll();
+        return;
+      }
+      case 'reset':
+        buffers.length = 1;
+        buffers[0] = '';
+        return;
+      case 'status':
+        buffers.length = 1;
+        buffers[0] = event.label;
+        lastEdit = Date.now();
+        await flushAll();
+        return;
+      case 'token': {
+        appendText(event.text);
+        const now = Date.now();
+        if (now - lastEdit > 1_000) {
+          lastEdit = now;
+          await flushAll();
+        }
       }
     }
   };
 
-  await produce(handleChunk);
+  await produce(handleEvent);
 
-  for (const [index, buffer] of buffers.entries()) {
-    await flush(index, buffer);
-  }
+  await flushAll();
 };
 
 export const safeStreamReplyToInteraction = async (
   interaction: StreamableInteraction,
-  produce: ChunkProducer,
+  produce: EventProducer,
   options?: StreamReplyOptions,
 ): Promise<Message[]> => {
   const {
@@ -261,7 +291,7 @@ export const safeStreamReplyToInteraction = async (
 
 export const safeStreamReplyToMessage = async (
   message: Message,
-  produce: ChunkProducer,
+  produce: EventProducer,
   options?: StreamReplyOptions,
 ): Promise<Message[]> => {
   const {

--- a/src/modules/chat/commands/chat/chat.ts
+++ b/src/modules/chat/commands/chat/chat.ts
@@ -294,10 +294,10 @@ const handleChatEmbed = async (interaction: ChatInputCommandInteraction) => {
   });
 
   try {
-    await safeStreamReplyToInteraction(interaction, async (onChunk) => {
+    await safeStreamReplyToInteraction(interaction, async (emit) => {
       await fillEmbeddings(options, async (chunk) => {
         if (!chunk.includes('{')) {
-          await onChunk(chunk);
+          await emit({ text: chunk, type: 'token' });
           return;
         }
 
@@ -307,9 +307,10 @@ const handleChatEmbed = async (interaction: ChatInputCommandInteraction) => {
           `${event.index} / ${event.total} | ${event.status}`,
         );
 
-        await onChunk(
-          `[${state}] ${event.name} (${inlineCode(event.model)})\n`,
-        );
+        await emit({
+          text: `[${state}] ${event.name} (${inlineCode(event.model)})\n`,
+          type: 'token',
+        });
       });
     });
   } catch (error) {

--- a/src/modules/chat/utils/reply.ts
+++ b/src/modules/chat/utils/reply.ts
@@ -101,16 +101,18 @@ export const handleChatMessage = async (message: Message) => {
     const startedAt = Date.now();
     const capture: { responseId: null | string } = { responseId: null };
 
-    const messages = await safeStreamReplyToMessage(
-      message,
-      async (onChunk) => {
-        capture.responseId = await sendPrompt(options, async (chunk) => {
+    const messages = await safeStreamReplyToMessage(message, async (emit) => {
+      capture.responseId = await sendPrompt(options, async (event) => {
+        if (event.type === 'reset') {
+          answer = '';
+        } else if (event.type === 'token') {
           firstChunkAt ??= Date.now();
-          answer += chunk;
-          await onChunk(chunk);
-        });
-      },
-    );
+          answer += event.text;
+        }
+
+        await emit(event);
+      });
+    });
 
     if (answer.length > 0) {
       const messageIds = messages.map((sent) => sent.id);

--- a/src/modules/chat/utils/reply.ts
+++ b/src/modules/chat/utils/reply.ts
@@ -105,6 +105,7 @@ export const handleChatMessage = async (message: Message) => {
       capture.responseId = await sendPrompt(options, async (event) => {
         if (event.type === 'reset') {
           answer = '';
+          firstChunkAt = null;
         } else if (event.type === 'token') {
           firstChunkAt ??= Date.now();
           answer += event.text;

--- a/src/modules/chat/utils/reply.ts
+++ b/src/modules/chat/utils/reply.ts
@@ -13,7 +13,12 @@ import {
   registerConversation,
 } from './conversation.js';
 import { attachFeedbackButtons, rememberFeedbackContext } from './feedback.js';
-import { sendPrompt } from './requests.js';
+import {
+  applyStreamEvent,
+  hasSavableAnswer,
+  sendPrompt,
+  type StreamAccumulator,
+} from './requests.js';
 import { appendTimingFootnote } from './timing.js';
 
 const COMMAND_LABEL = 'chat conversation continuation';
@@ -96,38 +101,41 @@ export const handleChatMessage = async (message: Message) => {
   }
 
   try {
-    let answer = '';
-    let firstChunkAt: null | number = null;
+    const state: StreamAccumulator = {
+      answer: '',
+      errored: false,
+      firstChunkAt: null,
+    };
     const startedAt = Date.now();
     const capture: { responseId: null | string } = { responseId: null };
 
     const messages = await safeStreamReplyToMessage(message, async (emit) => {
       capture.responseId = await sendPrompt(options, async (event) => {
-        if (event.type === 'reset') {
-          answer = '';
-          firstChunkAt = null;
-        } else if (event.type === 'token') {
-          firstChunkAt ??= Date.now();
-          answer += event.text;
-        }
-
+        applyStreamEvent(state, event);
         await emit(event);
       });
     });
 
-    if (answer.length > 0) {
+    if (hasSavableAnswer(state)) {
       const messageIds = messages.map((sent) => sent.id);
       registerConversation(inChatThread ? [message.channelId] : messageIds, [
         ...history,
         { content: prompt, role: 'user' },
-        { content: answer, role: 'assistant' },
+        { content: state.answer, role: 'assistant' },
       ]);
 
-      await appendTimingFootnote(messages.at(-1), startedAt, firstChunkAt);
+      await appendTimingFootnote(
+        messages.at(-1),
+        startedAt,
+        state.firstChunkAt,
+      );
 
       const { responseId } = capture;
       if (responseId !== null) {
-        rememberFeedbackContext(responseId, { answer, question: prompt });
+        rememberFeedbackContext(responseId, {
+          answer: state.answer,
+          question: prompt,
+        });
         await attachFeedbackButtons({
           askerId: message.author.id,
           guildId: message.guild?.id ?? null,

--- a/src/modules/chat/utils/requests.ts
+++ b/src/modules/chat/utils/requests.ts
@@ -106,6 +106,38 @@ const toStreamEvent = (sse: {
   }
 };
 
+export type StreamAccumulator = {
+  answer: string;
+  errored: boolean;
+  firstChunkAt: null | number;
+};
+
+export const applyStreamEvent = (
+  state: StreamAccumulator,
+  event: StreamEvent,
+): void => {
+  switch (event.type) {
+    case 'done':
+      break;
+    case 'error':
+      state.errored = true;
+      break;
+    case 'reset':
+      state.answer = '';
+      state.firstChunkAt = null; // so TTFT tracks the post-tool answer, not a preamble
+      break;
+    case 'status':
+      break;
+    case 'token':
+      state.firstChunkAt ??= Date.now();
+      state.answer += event.text;
+      break;
+  }
+};
+
+export const hasSavableAnswer = (state: StreamAccumulator): boolean =>
+  state.answer.length > 0 && !state.errored;
+
 export const sendPrompt = async (
   options: SendPromptOptions,
   onEvent: (event: StreamEvent) => Promise<void>,

--- a/src/modules/chat/utils/requests.ts
+++ b/src/modules/chat/utils/requests.ts
@@ -1,6 +1,8 @@
 import { createParser } from 'eventsource-parser';
 import { z } from 'zod';
 
+import type { StreamEvent } from '@/common/types/StreamEvent.js';
+
 import { logger } from '@/common/logger/index.js';
 import { getApiKey, getChatbotUrl } from '@/configuration/environment.js';
 import { QuestionsSchema } from '@/modules/faq/schemas/Question.js';
@@ -16,9 +18,22 @@ import type {
 
 import { sanitizeOptions } from './utils.js';
 
-// Await each chunk so the consumer finishes sending/editing its reply before the
+// Await each event so the consumer finishes sending/editing its reply before the
 // stream ends; firing them off unawaited lets the final flush race the in-flight
 // reply and post a duplicate message.
+const drainEvents = async (
+  pending: StreamEvent[],
+  onEvent: (event: StreamEvent) => Promise<void>,
+) => {
+  while (pending.length > 0) {
+    const event = pending.shift();
+    if (event !== undefined) {
+      await onEvent(event);
+    }
+  }
+};
+
+// fillEmbeddings streams plain text (no control events), so it keeps a string drain.
 const drainChunks = async (
   pending: string[],
   onChunk: (chunk: string) => Promise<void>,
@@ -31,9 +46,69 @@ const drainChunks = async (
   }
 };
 
+const asString = (value: unknown, fallback = ''): string =>
+  typeof value === 'string' ? value : fallback;
+
+const toStreamEvent = (sse: {
+  data: string;
+  event?: string | undefined;
+}): null | StreamEvent => {
+  const name = sse.event ?? '';
+  if (name === '' || name === 'message') {
+    // A bare `data:` frame (GPU passthrough) is answer text; the upstream escapes
+    // newlines as a literal "\n".
+    return { text: sse.data.replaceAll(String.raw`\n`, '\n'), type: 'token' };
+  }
+
+  const parsePayload = (): Record<string, unknown> => {
+    try {
+      const parsed = JSON.parse(sse.data) as unknown;
+      return typeof parsed === 'object' && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  };
+
+  const payload = parsePayload();
+
+  switch (name) {
+    case 'done':
+      return { type: 'done' };
+    case 'error':
+      return {
+        code: asString(payload['code'], 'error'),
+        message: asString(payload['message']),
+        type: 'error',
+      };
+    case 'reset':
+      return { type: 'reset' };
+    case 'status': {
+      const event: Extract<StreamEvent, { type: 'status' }> = {
+        label: asString(payload['label']),
+        type: 'status',
+      };
+      const state = asString(payload['state']);
+      if (state) {
+        event.state = state;
+      }
+      const tool = asString(payload['tool']);
+      if (tool) {
+        event.tool = tool;
+      }
+      return event;
+    }
+    case 'token':
+      return { text: asString(payload['text']), type: 'token' };
+    default:
+      return null;
+  }
+};
+
 export const sendPrompt = async (
   options: SendPromptOptions,
-  onChunk: (chunk: string) => Promise<void>,
+  onEvent: (event: StreamEvent) => Promise<void>,
 ) => {
   const chatbotUrl = getChatbotUrl();
 
@@ -67,12 +142,15 @@ export const sendPrompt = async (
   const responseId = result.headers.get('x-response-id');
 
   let receivedEvents = 0;
-  const pendingChunks: string[] = [];
+  const pendingEvents: StreamEvent[] = [];
 
   const parser = createParser({
-    onEvent: (event) => {
+    onEvent: (sse) => {
       receivedEvents++;
-      pendingChunks.push(event.data.replaceAll(String.raw`\n`, '\n'));
+      const event = toStreamEvent(sse);
+      if (event !== null) {
+        pendingEvents.push(event);
+      }
     },
   });
 
@@ -85,7 +163,7 @@ export const sendPrompt = async (
       break;
     }
     parser.feed(decoder.decode(value, { stream: true }));
-    await drainChunks(pendingChunks, onChunk);
+    await drainEvents(pendingEvents, onEvent);
   }
 
   if (receivedEvents === 0) {

--- a/src/modules/chat/utils/streaming.ts
+++ b/src/modules/chat/utils/streaming.ts
@@ -37,6 +37,7 @@ export const handlePromptWithStreaming = async (
         capture.responseId = await sendPrompt(options, async (event) => {
           if (event.type === 'reset') {
             answer = '';
+            firstChunkAt = null;
           } else if (event.type === 'token') {
             firstChunkAt ??= Date.now();
             answer += event.text;

--- a/src/modules/chat/utils/streaming.ts
+++ b/src/modules/chat/utils/streaming.ts
@@ -33,11 +33,16 @@ export const handlePromptWithStreaming = async (
 
     const messages = await safeStreamReplyToInteraction(
       interaction,
-      async (onChunk) => {
-        capture.responseId = await sendPrompt(options, async (chunk) => {
-          firstChunkAt ??= Date.now();
-          answer += chunk;
-          await onChunk(chunk);
+      async (emit) => {
+        capture.responseId = await sendPrompt(options, async (event) => {
+          if (event.type === 'reset') {
+            answer = '';
+          } else if (event.type === 'token') {
+            firstChunkAt ??= Date.now();
+            answer += event.text;
+          }
+
+          await emit(event);
         });
       },
     );

--- a/src/modules/chat/utils/streaming.ts
+++ b/src/modules/chat/utils/streaming.ts
@@ -14,7 +14,12 @@ import type { SendPromptOptions } from '../schemas/Chat.js';
 import { LLM_ERRORS } from './constants.js';
 import { registerConversation } from './conversation.js';
 import { attachFeedbackButtons, rememberFeedbackContext } from './feedback.js';
-import { sendPrompt } from './requests.js';
+import {
+  applyStreamEvent,
+  hasSavableAnswer,
+  sendPrompt,
+  type StreamAccumulator,
+} from './requests.js';
 import { appendTimingFootnote } from './timing.js';
 
 export const handlePromptWithStreaming = async (
@@ -26,8 +31,11 @@ export const handlePromptWithStreaming = async (
   commandLabel: string,
 ) => {
   try {
-    let answer = '';
-    let firstChunkAt: null | number = null;
+    const state: StreamAccumulator = {
+      answer: '',
+      errored: false,
+      firstChunkAt: null,
+    };
     const startedAt = Date.now();
     const capture: { responseId: null | string } = { responseId: null };
 
@@ -35,32 +43,29 @@ export const handlePromptWithStreaming = async (
       interaction,
       async (emit) => {
         capture.responseId = await sendPrompt(options, async (event) => {
-          if (event.type === 'reset') {
-            answer = '';
-            firstChunkAt = null;
-          } else if (event.type === 'token') {
-            firstChunkAt ??= Date.now();
-            answer += event.text;
-          }
-
+          applyStreamEvent(state, event);
           await emit(event);
         });
       },
     );
 
-    if (answer.length > 0) {
+    if (hasSavableAnswer(state)) {
       const messageIds = messages.map((message) => message.id);
       registerConversation(messageIds, [
         ...options.messages,
-        { content: answer, role: 'assistant' },
+        { content: state.answer, role: 'assistant' },
       ]);
 
-      await appendTimingFootnote(messages.at(-1), startedAt, firstChunkAt);
+      await appendTimingFootnote(
+        messages.at(-1),
+        startedAt,
+        state.firstChunkAt,
+      );
 
       const { responseId } = capture;
       if (responseId !== null) {
         rememberFeedbackContext(responseId, {
-          answer,
+          answer: state.answer,
           question: options.messages.at(-1)?.content,
         });
         await attachFeedbackButtons({


### PR DESCRIPTION
Consumes the new named-event chat stream (`token`/`status`/`reset`/`error`/`done`): the "🔍 Пребарувам…" status shows transiently and is replaced by the answer, a `reset` drops any pre-tool preamble, and errors/`done` are handled without polluting saved history. A bare `data:` frame stays supported for the GPU passthrough.

Wire-compatible; pairs with the API side in finki-hub/chat-bot#475. Verified: tsc + eslint, plus real-module harness (sendPrompt + safeStreamReplyToMessage) over the v2 frames.