### PR TITLE
feat(chat): distinct status label for the committee recommender tool

### DIFF
--- a/src/common/utils/messages.ts
+++ b/src/common/utils/messages.ts
@@ -8,7 +8,7 @@ import {
 
 import type { StreamEvent } from '@/common/types/StreamEvent.js';
 
-import { labels } from '@/translations/labels.js';
+import { labels, toolStatusLabels } from '@/translations/labels.js';
 
 type EventProducer = (
   emit: (event: StreamEvent) => Promise<void>,
@@ -187,12 +187,16 @@ const runStreaming = async (
         buffers.length = 1;
         buffers[0] = '';
         return;
-      case 'status':
+      case 'status': {
         buffers.length = 1;
-        buffers[0] = event.label;
+        const override = event.tool
+          ? toolStatusLabels.get(event.tool)
+          : undefined;
+        buffers[0] = override ?? event.label;
         lastEdit = Date.now();
         await flushAll();
         return;
+      }
       case 'token': {
         appendText(event.text);
         const now = Date.now();

--- a/src/translations/labels.ts
+++ b/src/translations/labels.ts
@@ -37,3 +37,9 @@ export const labels = {
   type: 'Тип',
   unknown: '?',
 };
+
+// Per-tool override for the transient chat status line, keyed by the (snake_case) tool name
+// the API sends in `status` events. Tools without an entry fall back to the generic label.
+export const toolStatusLabels = new Map<string, string>([
+  ['recommend_thesis_committee', '👥 Составувам комисија…'],
+]);

--- a/src/translations/labels.ts
+++ b/src/translations/labels.ts
@@ -38,8 +38,6 @@ export const labels = {
   unknown: '?',
 };
 
-// Per-tool override for the transient chat status line, keyed by the (snake_case) tool name
-// the API sends in `status` events. Tools without an entry fall back to the generic label.
 export const toolStatusLabels = new Map<string, string>([
   ['recommend_thesis_committee', '👥 Составувам комисија…'],
 ]);


### PR DESCRIPTION
When the agent calls `recommend_thesis_committee`, the transient status line shows **👥 Составувам комисија…** instead of the generic search label.

Uses the `tool` field already carried on the `status` SSE event (#788); any tool without an entry in `toolStatusLabels` falls back to the API-provided label.

Needs the recommender MCP tool (finki-hub/mcp#73) + endpoint (finki-hub/chat-bot#474).