### PR TITLE
fix(chat): preserve interrupted partial answers

### DIFF
--- a/src/modules/chat/utils/requests.ts
+++ b/src/modules/chat/utils/requests.ts
@@ -120,7 +120,13 @@ export const applyStreamEvent = (
     case 'done':
       break;
     case 'error':
-      state.errored = true;
+      // An `interrupted` error is emitted only after tokens have already
+      // streamed, so the partial answer is valid and worth keeping (history,
+      // feedback, timing). Other codes (no_answer, agent_error) arrive after a
+      // `reset`, leaving no answer to save.
+      if (event.code !== 'interrupted') {
+        state.errored = true;
+      }
       break;
     case 'reset':
       state.answer = '';


### PR DESCRIPTION
When the chat SSE stream ends with an `interrupted` error, the partial answer is now kept for conversation history, feedback, and timing instead of being discarded (other error codes still discard, as before).