### PR TITLE
fix(faq): show only the URL in link replies

### DIFF
--- a/src/modules/faq/commands/chat/link.ts
+++ b/src/modules/faq/commands/chat/link.ts
@@ -1,5 +1,4 @@
 import {
-  bold,
   type ChatInputCommandInteraction,
   MessageFlags,
   SlashCommandBuilder,
@@ -12,7 +11,6 @@ import {
   commandErrors,
   commandResponseFunctions,
 } from '@/translations/commands.js';
-import { labels } from '@/translations/labels.js';
 
 export const name = 'link';
 
@@ -48,14 +46,11 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
   }
 
   const normalizedUrl = getNormalizedUrl(link.url);
-  const noteLabel = `${labels.note}:`;
-  const note =
-    link.description === null ? '' : `\n${bold(noteLabel)} ${link.description}`;
 
   await interaction.editReply({
     content: user
-      ? `${commandResponseFunctions.commandFor(user.id)}\n${normalizedUrl}${note}`
-      : `${normalizedUrl}${note}`,
+      ? `${commandResponseFunctions.commandFor(user.id)}\n${normalizedUrl}`
+      : normalizedUrl,
     flags: MessageFlags.SuppressEmbeds,
   });
 };


### PR DESCRIPTION
## Summary
- remove link descriptions from /link command replies
- keep normalized URL output, optional user prefix, and embed suppression

## Verification
- npm run check
- npm run lint
- npm run build
- manual /link handler driver with fake chatbot API verified URL-only, user-prefix, and not-found paths