### PR TITLE
fix(chat): disable reasoning for /ask

### DIFF
--- a/src/modules/chat/commands/chat/ask.ts
+++ b/src/modules/chat/commands/chat/ask.ts
@@ -1,6 +1,6 @@
 import { getCommonCommand } from '@/modules/chat/utils/chatCommand.js';
 
-const { data, execute } = getCommonCommand('ask');
+const { data, execute } = getCommonCommand('ask', { allowReasoning: false });
 
 export { data, execute };
 export const name = 'ask';

--- a/src/modules/chat/utils/chatCommand.ts
+++ b/src/modules/chat/utils/chatCommand.ts
@@ -14,8 +14,15 @@ import { resolveInteractionChatUser } from './interaction.js';
 import { getSupportedModels, getValidatedInferenceModel } from './requests.js';
 import { handlePromptWithStreaming } from './streaming.js';
 
-export const getCommonCommand = (name: keyof typeof commandDescriptions) => ({
-  data: new SlashCommandBuilder()
+type CommonCommandOptions = {
+  readonly allowReasoning?: boolean;
+};
+
+export const getCommonCommand = (
+  name: keyof typeof commandDescriptions,
+  { allowReasoning = true }: CommonCommandOptions = {},
+) => {
+  const data = new SlashCommandBuilder()
     .setName(name)
     .setDescription(commandDescriptions[name])
     .addStringOption((option) =>
@@ -24,17 +31,20 @@ export const getCommonCommand = (name: keyof typeof commandDescriptions) => ({
         .setDescription('Промпт за LLM агентот')
         .setRequired(true)
         .setMaxLength(2_000),
-    )
-    .addBooleanOption((option) =>
+    );
+
+  if (allowReasoning) {
+    data.addBooleanOption((option) =>
       option
         .setName('reasoning')
         .setDescription(
           'Овозможи размислување пред одговор (ако моделот поддржува)',
         )
         .setRequired(false),
-    ),
+    );
+  }
 
-  execute: async (interaction: ChatInputCommandInteraction) => {
+  const execute = async (interaction: ChatInputCommandInteraction) => {
     const prompt = interaction.options.getString('prompt', true);
     const embeddingsModel =
       interaction.options.getString('embeddings-model') ?? undefined;
@@ -44,7 +54,9 @@ export const getCommonCommand = (name: keyof typeof commandDescriptions) => ({
       interaction.options.getNumber('temperature') ?? undefined;
     const topP = interaction.options.getNumber('top-p') ?? undefined;
     const maxTokens = interaction.options.getNumber('max-tokens') ?? undefined;
-    const reasoning = interaction.options.getBoolean('reasoning') ?? undefined;
+    const reasoning = allowReasoning
+      ? (interaction.options.getBoolean('reasoning') ?? undefined)
+      : false;
 
     const models =
       interaction.guild === null
@@ -96,5 +108,7 @@ export const getCommonCommand = (name: keyof typeof commandDescriptions) => ({
     });
 
     await handlePromptWithStreaming(interaction, options, 'chat query command');
-  },
-});
+  };
+
+  return { data, execute };
+};

--- a/test/modules/chat/askCommand.test.ts
+++ b/test/modules/chat/askCommand.test.ts
@@ -1,0 +1,77 @@
+import type { ChatInputCommandInteraction } from 'discord.js';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SendPromptOptions } from '@/modules/chat/schemas/Chat.js';
+import type { ChatUser } from '@/modules/chat/schemas/Credentials.js';
+
+import { data, execute } from '@/modules/chat/commands/chat/ask.js';
+
+type HandlePromptMock = (
+  interaction: ChatInputCommandInteraction,
+  options: SendPromptOptions,
+  commandLabel: string,
+) => Promise<void>;
+type ResolveChatUserMock = (
+  interaction: ChatInputCommandInteraction,
+) => Promise<ChatUser | null>;
+type ResolveModelMock = (
+  userId: string,
+  configuredModel: string | undefined,
+) => Promise<string | undefined>;
+
+const mocks = vi.hoisted(() => ({
+  handlePrompt: vi.fn<HandlePromptMock>(async () => {}),
+  resolveChatUser: vi.fn<ResolveChatUserMock>(async () => ({
+    id: '00000000-0000-4000-8000-000000000001',
+    provider: 'discord',
+    provider_subject: 'discord-user',
+  })),
+  resolveModel: vi.fn<ResolveModelMock>(async () => 'gpt-5.6-luna'),
+}));
+
+vi.mock('@/modules/chat/utils/interaction.js', () => ({
+  resolveInteractionChatUser: mocks.resolveChatUser,
+}));
+
+vi.mock('@/modules/chat/utils/requests.js', () => ({
+  getSupportedModels: vi.fn<() => Promise<null>>(async () => null),
+  getValidatedInferenceModel: mocks.resolveModel,
+}));
+
+vi.mock('@/modules/chat/utils/streaming.js', () => ({
+  handlePromptWithStreaming: mocks.handlePrompt,
+}));
+
+describe('/ask command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('exposes only the prompt option', () => {
+    const optionNames = data.toJSON().options?.map((option) => option.name);
+
+    expect(optionNames).toEqual(['prompt']);
+  });
+
+  test('disables reasoning without reading an interaction option', async () => {
+    const getBoolean = vi.fn<(name: string) => boolean>(() => true);
+    const interaction = {
+      guild: null,
+      options: {
+        getBoolean,
+        getNumber: () => null,
+        getString: (name: string) => (name === 'prompt' ? 'question' : null),
+      },
+    } as unknown as ChatInputCommandInteraction;
+
+    await execute(interaction);
+
+    expect(getBoolean).not.toHaveBeenCalled();
+    expect(mocks.handlePrompt).toHaveBeenCalledWith(
+      interaction,
+      expect.objectContaining({ reasoning: false }),
+      'chat query command',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- remove the `reasoning` option from `/ask`
- always send `reasoning: false` for `/ask` while preserving `/chat query` behavior
- add focused command-schema and execution regression tests

## Testing
- `npm test`
- `npm run check`
- `npm run lint`
- `npm run build`